### PR TITLE
Add additional Claude Code permission rules

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,10 @@
 {
   "permissions": {
     "allow": [
+      "Bash(make test:*)",
+      "Bash(make install:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
       "Bash(wc:*)",
       "Bash(grep:*)",
       "Bash(ls:*)"


### PR DESCRIPTION
## Summary
- Expand allowed bash commands in Claude Code settings to include `make test/install` and `git add/commit` for streamlined development workflow

## Test plan
- [x] Verify settings.json is valid JSON
- [x] Confirm permissions are correctly formatted