### PR TITLE
Fix aluminum preset unit test after merge

### DIFF
--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -43,7 +43,7 @@ class TestMaterialPresets(unittest.TestCase):
         self.assertEqual(pp.feed_rate, 55.0)
         self.assertEqual(pp.spindle_speed, 18000)
         self.assertEqual(pp.ramp_angle, 4.0)
-        self.assertEqual(pp.stepover_percentage, 0.45)
+        self.assertEqual(pp.stepover_percentage, 0.25)
 
     def test_polycarbonate_preset_applies_correctly(self):
         pp = FRCPostProcessor(0.25, 0.157)


### PR DESCRIPTION
## Summary

Update unit test to match the aluminum stepover change from PR #4.

## Changes

- `tests/test_unit.py`: Update expected `stepover_percentage` from 0.45 to 0.25 for aluminum preset

## Context

After merging main (which added unit tests) into the feature branch, the test for aluminum preset failed because it expected the old stepover value (0.45) instead of the new value (0.25) set in PR #4.

## Test plan
- [x] `make test` passes (all 22 tests)