### PR TITLE
Add stock size display to G-code preview

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -633,6 +633,30 @@
             font-weight: 500;
         }
 
+        /* Stock Size Display */
+        .stock-size-display {
+            background: var(--surface-light);
+            border-radius: 6px;
+            padding: 0.6rem 1rem;
+            margin-bottom: 1rem;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 0.5rem;
+        }
+
+        .stock-size-label {
+            color: var(--text-dim);
+            font-size: 0.85rem;
+        }
+
+        .stock-size-value {
+            color: var(--primary);
+            font-weight: 600;
+            font-size: 0.95rem;
+            font-family: 'Monaco', 'Courier New', monospace;
+        }
+
         /* DXF Setup View */
         #dxf-setup-container {
             background: var(--surface);

--- a/templates/index.html
+++ b/templates/index.html
@@ -212,6 +212,12 @@
                         </div>
                     </div>
 
+                    <!-- Stock Size Display (shown in preview mode) -->
+                    <div id="stockSizeDisplay" class="stock-size-display" style="display: none;">
+                        <span class="stock-size-label">Stock Size:</span>
+                        <span id="stockSizeValue" class="stock-size-value">—</span>
+                    </div>
+
                     <!-- DXF Setup View (2D) -->
                     <div id="dxf-setup-container" style="display: none;">
                         <div class="setup-info">


### PR DESCRIPTION
## Summary
- Adds a stock size header at the top of the G-code preview panel
- **For plates**: Shows DXF dimensions + tool diameter margin (only when toolpath cuts outside the part perimeter)
- **For aluminum tubes**: Shows full 3D tube profile (width × height × length) derived from tube height setting and DXF dimensions

## How it works

### Plates
- Uses DXF bounding box as base dimensions
- Detects if toolpath extends beyond DXF bounds (perimeter cutting)
- Only adds 2× tool diameter margin on axes where tool cuts outside
- Accounts for part rotation (90°/270°)

### Aluminum Tubes
- Tube width: derived from DXF short dimension (1" or 2")
- Tube height: from the Tube Z-Height form input (1" or 2")
- Tube length: from DXF long dimension
- Displays as: `2" × 1" × 20.000"` (width × height × length)

## Test plan
- [ ] Generate G-code for a plate with perimeter cutting → verify margin is added
- [ ] Generate G-code for a plate with only internal features → verify no margin
- [ ] Generate G-code for aluminum tube → verify 3D dimensions shown
- [ ] Test with different tube heights (1" vs 2")

🤖 Generated with [Claude Code](https://claude.com/claude-code)