### PR TITLE
Add parametric tube facing and cut-to-length operations

### DIFF
--- a/frc_cam_postprocessor.py
+++ b/frc_cam_postprocessor.py
@@ -2495,10 +2495,10 @@ class FRCPostProcessor:
         # With positive J, G3 arc bulges toward +Y (into waste) by arc_bulge amount
         # At arc peak: tool center Y = roughing_y + arc_bulge
         # At arc peak: tool -Y edge = roughing_y + arc_bulge - tool_radius
-        # For roughing to cut up to (y_cut - finish_stock):
-        #   roughing_y + arc_bulge - tool_radius = y_cut - finish_stock
-        #   roughing_y = y_cut - finish_stock - arc_bulge + tool_radius
-        roughing_y = (y_cut - finish_stock) - arc_bulge + tool_radius
+        # For roughing to LEAVE finish_stock, cut to (y_cut + finish_stock):
+        #   roughing_y + arc_bulge - tool_radius = y_cut + finish_stock
+        #   roughing_y = y_cut + finish_stock - arc_bulge + tool_radius
+        roughing_y = (y_cut + finish_stock) - arc_bulge + tool_radius
         finishing_y = y_cut + tool_radius
 
         # X positions (outside tube by 1.5x tool diameter)

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -115,8 +115,8 @@ class TestHoleClassification(unittest.TestCase):
             {'center': (2, 2), 'radius': 0.05, 'diameter': 0.1},  # 0.1" < 0.1884" - skip
         ]
         self.pp.classify_holes()
-        self.assertEqual(len(self.pp.bearing_holes), 1)
-        self.assertEqual(self.pp.bearing_holes[0]['center'], (1, 1))
+        self.assertEqual(len(self.pp.holes), 1)
+        self.assertEqual(self.pp.holes[0]['center'], (1, 1))
 
     def test_all_large_holes_are_kept(self):
         self.pp.circles = [
@@ -125,7 +125,7 @@ class TestHoleClassification(unittest.TestCase):
             {'center': (3, 3), 'radius': 0.375, 'diameter': 0.75},
         ]
         self.pp.classify_holes()
-        self.assertEqual(len(self.pp.bearing_holes), 3)
+        self.assertEqual(len(self.pp.holes), 3)
 
     def test_holes_at_exactly_min_millable_are_kept(self):
         # Holes at exactly min_millable_hole are kept (code uses < not <=)
@@ -134,7 +134,7 @@ class TestHoleClassification(unittest.TestCase):
             {'center': (1, 1), 'radius': exact_min / 2, 'diameter': exact_min},
         ]
         self.pp.classify_holes()
-        self.assertEqual(len(self.pp.bearing_holes), 1)
+        self.assertEqual(len(self.pp.holes), 1)
 
 
 class TestHoleSorting(unittest.TestCase):
@@ -153,7 +153,7 @@ class TestHoleSorting(unittest.TestCase):
         self.pp.classify_holes()
 
         # Should be sorted by X first, then Y
-        centers = [h['center'] for h in self.pp.bearing_holes]
+        centers = [h['center'] for h in self.pp.holes]
         self.assertEqual(centers[0], (1, 1))  # x=1, y=1
         self.assertEqual(centers[1], (1, 3))  # x=1, y=3
         self.assertEqual(centers[2], (3, 2))  # x=3
@@ -164,8 +164,8 @@ class TestHoleSorting(unittest.TestCase):
             {'center': (5, 5), 'radius': 0.25, 'diameter': 0.5},
         ]
         self.pp.classify_holes()
-        self.assertEqual(len(self.pp.bearing_holes), 1)
-        self.assertEqual(self.pp.bearing_holes[0]['center'], (5, 5))
+        self.assertEqual(len(self.pp.holes), 1)
+        self.assertEqual(self.pp.holes[0]['center'], (5, 5))
 
 
 class TestPocketCircularDetection(unittest.TestCase):


### PR DESCRIPTION
## Summary

- Replace scaled Fusion 360 toolpath approach with parametric arc clearing pattern for tube facing
- Implement consistent arc clearing for cut-to-length operations
- Fix arc visualization by using positive J offset (arcs now visible in 3D preview)

## Changes

### Tube Facing (Square End)
- **Arc clearing pattern**: Roughing pass uses small CCW arcs (0.05" radius) across tube width to reduce chip load
- **Finishing pass**: Single straight cut at final depth
- **Two-phase operation**: 
  - Phase 1: Face first end with +0.0625" Y offset
  - Phase 2: Face second end to Y=0 after flip

### Cut-to-Length
- Arc clearing pattern matching the facing approach
- Positive J offset for consistent arc visualization (G3 takes "long path")
- Single plunge to just over half tube height
- Proper tool edge positioning for clean cuts

### Technical Details
- Arc parameters: 0.05" radius, 0.04" advance per arc
- Plunge depth: `tube_height/2 + 0.05"` (just over half height)
- Clearance: 1.5× tool diameter outside tube edges
- Default 2×1 tube size now uses flat orientation (most common)

## Test plan

- [x] All 45 existing tests pass
- [ ] Generate tube facing G-code for 1×1 tube - verify arc pattern
- [ ] Generate tube facing G-code for 2×1 tube - verify scaling
- [ ] Enable cut-to-length - verify arcs at both ends visible in preview
- [ ] Run on actual CNC machine with test piece

🤖 Generated with [Claude Code](https://claude.com/claude-code)