### PR TITLE
Clamp pocket helix entry and reject non-circular pockets

### DIFF
--- a/frc_cam_postprocessor.py
+++ b/frc_cam_postprocessor.py
@@ -2586,6 +2586,40 @@ class FRCPostProcessor:
             }
         )
 
+    def _clamped_helix_radius(self, travel_region, entry_x: float, entry_y: float) -> float:
+        """Preset helix entry radius, clamped so the helix cannot cut outside the feature.
+
+        `travel_region` is the tool-CENTER travel area (the tool-compensated pocket), so a
+        helix of radius r about the entry point stays inside the finished feature exactly
+        when r <= distance(entry, travel_region.boundary).
+
+        The preset radius (tool_radius * helix_radius_multiplier) is sized for open pockets
+        and is not bounded by the feature. On any feature narrower than
+        2 * tool_radius * (1 + helix_radius_multiplier) the unclamped helix sweeps a circle
+        wider than the pocket itself and gouges the wall - the finished feature then comes
+        out at the helix diameter, not the programmed one.
+
+        No lower floor is applied. A floor expressed as a fraction of tool_radius can itself
+        exceed the geometric limit on a small feature, which is the very gouge being
+        prevented; the caller is responsible for rejecting a radius too small to be useful.
+
+        Returns:
+            Helix radius in the caller's units, always <= 90% of the geometric limit.
+        """
+        preset = self.tool_radius * self.helix_radius_multiplier
+        max_radius = travel_region.boundary.distance(Point(entry_x, entry_y))
+        if max_radius <= 0:
+            return preset
+        return min(preset, max_radius * 0.9)
+
+    def _helix_too_small(self, helix_radius: float) -> bool:
+        """True if a helix of this radius is too tight to be a meaningful entry move.
+
+        Below this the helix degenerates toward a straight plunge and the pass count
+        explodes, so the caller should reject the feature instead of emitting it.
+        """
+        return helix_radius < self.tool_radius * 0.05
+
     def _calculate_helical_passes(self, toolpath_radius: float, target_angle_deg: float = None, ramp_start_height: float = None) -> Tuple[int, float]:
         """
         Calculate number of helical passes needed for a safe plunge angle.
@@ -3183,12 +3217,25 @@ class FRCPostProcessor:
         entry_x = entry_point.x
         entry_y = entry_point.y
 
-        # Calculate helical entry parameters
-        helix_radius = self.tool_radius * self.helix_radius_multiplier  # Helix radius from material preset
+        # Calculate helical entry parameters. The preset radius must be clamped to the
+        # pocket: unclamped, a small pocket is bored out to the helix diameter instead of
+        # its own.
+        preset_helix_radius = self.tool_radius * self.helix_radius_multiplier
+        helix_radius = self._clamped_helix_radius(offset_poly, entry_x, entry_y)
+        if self._helix_too_small(helix_radius):
+            center_x, center_y = self._get_polygon_center(pocket_poly)
+            self._add_error(
+                f"Pocket at approximately ({center_x:.3f}, {center_y:.3f}) is too small for a "
+                f"helical entry with the {self.tool_diameter:.4f}\" tool - use a smaller tool "
+                f"or a peck-drilled entry")
+            return gcode
         ramp_start_height = self.material_top + self.ramp_start_clearance
         num_helical_passes, depth_per_pass = self._calculate_helical_passes(helix_radius, ramp_start_height=ramp_start_height)
 
         gcode.append(f"(Pocket with helical entry at center: {num_helical_passes} passes at {self.ramp_angle} deg)")
+        if helix_radius < preset_helix_radius - 1e-9:
+            gcode.append(f"(Helix entry radius reduced from {preset_helix_radius:.4f} to "
+                         f"{helix_radius:.4f} to stay inside this pocket)")
 
         # Position at pocket center
         gcode.append(f"G1 X{entry_x:.4f} Y{entry_y:.4f} F{self.traverse_rate}  ; Position at pocket center")
@@ -3307,9 +3354,28 @@ class FRCPostProcessor:
         if circularity < 0.95:
             return None
 
+        # Circularity alone does NOT separate a circle from a near-round obround. A 4.0 mm
+        # wide slot with only 0.69 mm of straight section scores 0.988 - comfortably inside
+        # the 0.95 gate - and would then be cleared as a circle of entirely the wrong size.
+        # Vertex distance from the centroid does separate them cleanly: every vertex of a
+        # polygon inscribed in a circle lies at exactly R for ANY tessellation density, so a
+        # true circle scores 1.000 no matter how coarsely the DXF arc was sampled, while that
+        # slot spans 1.97-2.34 mm (ratio 1.19). Tightening the circularity threshold instead
+        # would not work - it would have to exceed 0.99 to reject the slot, which starts
+        # rejecting coarsely tessellated real circles.
         centroid = polygon.centroid
-        radius = math.sqrt(area / math.pi)
-        return (centroid.x, centroid.y, radius)
+        distances = [math.hypot(x - centroid.x, y - centroid.y)
+                     for x, y in polygon.exterior.coords[:-1]]
+        if not distances:
+            return None
+        r_min = min(distances)
+        r_max = max(distances)
+        if r_min <= 0 or (r_max / r_min) > 1.02:
+            return None
+
+        # Measured radius, not sqrt(area/pi): the equal-area radius is only correct for a
+        # genuine circle, and reporting it invites reuse on shapes that are not one.
+        return (centroid.x, centroid.y, (r_min + r_max) / 2)
 
     def _detect_circular_ring(self, polygon: Polygon) -> Optional[Tuple[float, float, float, float]]:
         """Check if a polygon with interiors is approximately a circular ring.
@@ -3573,19 +3639,25 @@ class FRCPostProcessor:
             entry_x = offset_poly.centroid.x
             entry_y = offset_poly.centroid.y
 
-        # Calculate helical entry parameters
-        helix_radius = self.tool_radius * self.helix_radius_multiplier
-
-        # Adapt helix radius to fit within available space
-        # The max helix radius at the entry point is the distance from entry to nearest boundary
-        max_helix_radius = offset_poly.boundary.distance(Point(entry_x, entry_y))
-        if helix_radius > max_helix_radius * 0.9:  # 90% safety factor
-            helix_radius = max(max_helix_radius * 0.9, self.tool_radius * 0.25)  # Floor at 25% of tool_radius
+        # Calculate helical entry parameters. This previously clamped to the boundary but
+        # then re-floored at 25% of tool_radius, and that floor can exceed the boundary
+        # distance on a small pocket - reintroducing the gouge the clamp exists to prevent.
+        preset_helix_radius = self.tool_radius * self.helix_radius_multiplier
+        helix_radius = self._clamped_helix_radius(offset_poly, entry_x, entry_y)
+        if self._helix_too_small(helix_radius):
+            self._add_error(
+                f"Pocket at approximately ({entry_x:.3f}, {entry_y:.3f}) is too small for a "
+                f"helical entry with the {self.tool_diameter:.4f}\" tool - use a smaller tool "
+                f"or a peck-drilled entry")
+            return gcode
 
         ramp_start_height = self.material_top + self.ramp_start_clearance
         num_helical_passes, depth_per_pass = self._calculate_helical_passes(helix_radius, ramp_start_height=ramp_start_height)
 
         gcode.append(f"(Island-aware pocket with helical entry: {num_helical_passes} passes at {self.ramp_angle} deg)")
+        if helix_radius < preset_helix_radius - 1e-9:
+            gcode.append(f"(Helix entry radius reduced from {preset_helix_radius:.4f} to "
+                         f"{helix_radius:.4f} to stay inside this pocket)")
 
         # Position at entry point
         gcode.append(f"G1 X{entry_x:.4f} Y{entry_y:.4f} F{self.traverse_rate}  ; Position at entry point")

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -20,6 +20,8 @@ from frc_cam_postprocessor import (
 )
 from team_config import TeamConfig, parse_length, DEFAULT_TOOL_DIAMETER_IN
 from onshape_integration import OnshapeClient
+from shapely.geometry import Point
+from shapely.ops import unary_union
 
 
 class TestControllerPortability(unittest.TestCase):
@@ -412,6 +414,108 @@ class TestMaterialPresets(unittest.TestCase):
         pp.apply_material_preset('plywood')
         # 75 IPM * 25.4 = 1905 mm/min
         self.assertEqual(pp.feed_rate, 75.0 * 25.4)
+
+
+class TestSolidCircleDetection(unittest.TestCase):
+    """Circle detection must not accept a near-round obround slot.
+
+    Regression: a 4.0 mm wide slot with 0.69 mm of straight section scores 0.988 on the
+    isoperimetric quotient, passing the 0.95 gate. It was then cleared as a circle sized
+    by sqrt(area/pi), producing a round hole ~0.35 mm oversize instead of a slot.
+    """
+
+    MM = 25.4
+
+    def setUp(self):
+        self.pp = FRCPostProcessor(0.25, 0.125)
+        self.pp.apply_material_preset('plywood')
+
+    def _obround(self, width_mm, straight_mm, quad_segs=64):
+        r = (width_mm / 2) / self.MM
+        half = (straight_mm / 2) / self.MM
+        return unary_union([Point(-half, 0).buffer(r, quad_segs=quad_segs),
+                            Point(half, 0).buffer(r, quad_segs=quad_segs)])
+
+    def _circle(self, diameter_mm, quad_segs):
+        return Point(0, 0).buffer((diameter_mm / 2) / self.MM, quad_segs=quad_segs)
+
+    def test_rejects_near_round_obround_slot(self):
+        # The exact geometry that shipped as 5.08 mm round holes.
+        self.assertIsNone(self.pp._detect_solid_circle(self._obround(4.0, 0.6863)))
+
+    def test_rejects_longer_obround_slot(self):
+        self.assertIsNone(self.pp._detect_solid_circle(self._obround(4.0, 1.3726)))
+
+    def test_accepts_circle_at_any_tessellation_density(self):
+        # Every vertex of a polygon inscribed in a circle sits at exactly R, so a coarse
+        # DXF arc must still be recognised. This is why the fix is a radial test and not
+        # a tighter circularity threshold.
+        for quad_segs in (4, 8, 16, 64):
+            with self.subTest(quad_segs=quad_segs):
+                self.assertIsNotNone(self.pp._detect_solid_circle(self._circle(4.0, quad_segs)))
+
+    def test_reports_measured_radius_not_equal_area_radius(self):
+        result = self.pp._detect_solid_circle(self._circle(14.0, 64))
+        self.assertIsNotNone(result)
+        self.assertAlmostEqual(result[2] * self.MM, 7.0, places=3)
+
+
+class TestHelixRadiusClamp(unittest.TestCase):
+    """The helix entry must never sweep outside the feature it is entering.
+
+    Regression: helix_radius = tool_radius * helix_radius_multiplier was unbounded, so any
+    pocket narrower than 2 * tool_radius * (1 + multiplier) was bored out to the helix
+    diameter. With a 1/8" tool at multiplier 0.60 that is every feature under 5.08 mm.
+    """
+
+    MM = 25.4
+
+    def setUp(self):
+        self.pp = FRCPostProcessor(0.25, 0.125)
+        self.pp.apply_material_preset('plywood')
+        self.pp.helix_radius_multiplier = 0.60
+
+    def _entry(self, travel_region):
+        point = travel_region.centroid
+        if not travel_region.contains(point):
+            point = travel_region.representative_point()
+        return point
+
+    def _assert_inside(self, feature_poly):
+        travel = feature_poly.buffer(-self.pp.tool_radius)
+        entry = self._entry(travel)
+        radius = self.pp._clamped_helix_radius(travel, entry.x, entry.y)
+        limit = travel.boundary.distance(Point(entry.x, entry.y))
+        self.assertLessEqual(radius, limit,
+                             "helix would cut outside the finished feature")
+        return radius, limit
+
+    def test_helix_stays_inside_small_circular_pocket(self):
+        for diameter_mm in (3.5, 4.0, 4.5, 5.0, 5.08, 6.0, 14.0):
+            with self.subTest(diameter_mm=diameter_mm):
+                self._assert_inside(Point(0, 0).buffer((diameter_mm / 2) / self.MM, quad_segs=64))
+
+    def test_small_pocket_is_clamped_below_preset(self):
+        radius, _ = self._assert_inside(Point(0, 0).buffer((4.0 / 2) / self.MM, quad_segs=64))
+        self.assertLess(radius, self.pp.tool_radius * self.pp.helix_radius_multiplier)
+
+    def test_large_pocket_keeps_the_preset_radius(self):
+        radius, _ = self._assert_inside(Point(0, 0).buffer((14.0 / 2) / self.MM, quad_segs=64))
+        self.assertAlmostEqual(radius, self.pp.tool_radius * self.pp.helix_radius_multiplier)
+
+    def test_no_floor_is_applied_above_the_geometric_limit(self):
+        # The previous clamp re-floored at 0.25 * tool_radius, which on these two slots
+        # exceeds the boundary distance and so gouged despite the clamp being present.
+        for straight_mm in (0.6863, 1.3726):
+            with self.subTest(straight_mm=straight_mm):
+                r = (4.0 / 2) / self.MM
+                half = (straight_mm / 2) / self.MM
+                slot = unary_union([Point(-half, 0).buffer(r, quad_segs=64),
+                                    Point(half, 0).buffer(r, quad_segs=64)])
+                radius, limit = self._assert_inside(slot)
+                self.assertLess(limit, self.pp.tool_radius * 0.25,
+                                "test geometry no longer exercises the floor bug")
+                self.assertLess(radius, self.pp.tool_radius * 0.25)
 
 
 class TestHelicalPassCalculation(unittest.TestCase):


### PR DESCRIPTION
Two bugs cause every pocket narrower than `2 * tool_radius * (1 + helix_radius_multiplier)` to be cut oversize.

**`_detect_solid_circle`** used only the isoperimetric quotient against a 0.95 threshold, which doesn't separate a circle from a near-round obround - a 4.00 mm slot with 0.69 mm of straight section scores 0.988. Misclassified pockets were then cleared as a circle sized by `sqrt(area/pi)`, which is only correct for a real circle. Adds a vertex-radial test (every vertex of a polygon inscribed in a circle lies at exactly R, at any tessellation density) and returns the measured radius.

**`_generate_pocket_gcode`** set `helix_radius` from the material preset with nothing bounding it to the pocket, so the entry helix swept wider than the finished feature. Not limited to misclassified slots: a genuine 4.00 mm circular pocket allows at most 0.4123 mm while the preset asks for 0.9525. `_generate_pocket_gcode_from_polygon` did clamp, but re-floored at `0.25 * tool_radius`, which can exceed the limit it was meant to respect. Both now share `_clamped_helix_radius` (no floor), plus `_helix_too_small` so callers can reject a feature instead of emitting a pathological helix.

`_generate_contour_gcode` is also unclamped but runs into scrap, so it's unchanged.

Adds `TestSolidCircleDetection` and `TestHelixRadiusClamp` - neither function had prior coverage. Full suite passes.

**Tested on hardware:** STEPCRAFT D.600 / UCCNC, 3 mm acetal, Amana 51411 (1/8" single-flute O-flute upcut). Test part has 29 obround slots at 4.00 mm wide plus four 14 mm bores. Before: all 29 slots cut as 5.08 mm round holes. After: 4.00 mm wide with correct slot length, bores unchanged.